### PR TITLE
Enable injection of routes file path

### DIFF
--- a/SlimAdditions/RouteGenerator.php
+++ b/SlimAdditions/RouteGenerator.php
@@ -67,8 +67,8 @@ class RouteGenerator
         \Slim\Route::setDefaultConditions($conditions);
     }
 
-    public function loadRoutes()
+    public function loadRoutes($path = 'config/routes.php')
     {
-        include 'config/routes.php';
+        include $path;
     }
 }


### PR DESCRIPTION
Howdy Dave. I'm working on a way to bootstrap the Slim app for PHPUnit integration testing and ran into this hardcoded dependency. Would like to be able to call loadRoutes() from a different working directory. Make sense?
